### PR TITLE
Fix: Initialize Baz property in Bar class to prevent NullReferenceExc…

### DIFF
--- a/src/BuggyDemoConsole/Models/Foo.cs
+++ b/src/BuggyDemoConsole/Models/Foo.cs
@@ -13,7 +13,7 @@ namespace BuggyDemoConsole.Models
 
     public class Bar
     {
-        public Baz Baz { get; set; }
+    public Baz Baz { get; set; } = new Baz(); // Initialize Baz here
     }
 
     public class Baz


### PR DESCRIPTION
…eption

The Baz property in the Bar class was not initialized, leading to a NullReferenceException when accessing Bar.Baz.Name.

This commit initializes the Baz property inline within the Bar class to ensure it's not null when accessed.